### PR TITLE
Change package state setting of ansible from installed to present

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     update_cache: yes
 
 - name: Yarn | Install package
-  apt: name={{ item }} state=installed update_cache=yes cache_valid_time=3600
+  apt: name={{ item }} state=present update_cache=yes cache_valid_time=3600
   with_items:
     - yarn
   become: yes


### PR DESCRIPTION
This PR changes the package state setting of ansible from 'installed' to 'present', because State 'installed' is deprecated.

## warning
```
[DEPRECATION WARNING]: State 'installed' is deprecated. Using state 'present' instead.. This feature will be removed in 
version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```